### PR TITLE
Add 'Amplify CLI Deep Dive' presented at AWS DevDay Online Japan.

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -11,6 +11,7 @@
 - [フロントエンドエンジニアに捧げるAWS Amplify Console](https://dev.classmethod.jp/articles/aws-amplify-console-guide-lines-for-frontend-engineer/)
 - [フロントエンドエンジニアのためのAWSアーキテクチャ](https://speakerdeck.com/tmizuma/hurontoentoensiniafalsetamefalseawsakitekutiya)
 - [AWS Amplify 実践編](https://speakerdeck.com/jaguar_imo/practical-aws-amplify-at-aws-dev-day-2020)
+- [Amplify CLI Deep Dive ](https://speakerdeck.com/jaguar_imo/amplify-cli-deep-dive-awsdevday-2020)
 - [AmplifyとAppSyncでモダンでイケてるWebサービスを爆速で立ち上げようぜ](https://dev.classmethod.jp/articles/amplify-appsync-bakusoku-devio2020/)
 
 ## ワークショップ


### PR DESCRIPTION
Add 'Amplify CLI Deep Dive' presented at AWS DevDay Online Japan.

I recommend watching this slide so you can learn more about the Amplify CLI.


